### PR TITLE
Fix Restarting screen time service when the device is restarted

### DIFF
--- a/android/app/src/main/kotlin/work/racka/reluct/ReluctApplication.kt
+++ b/android/app/src/main/kotlin/work/racka/reluct/ReluctApplication.kt
@@ -38,9 +38,7 @@ class ReluctApplication : Application() {
                 val screenTimeServices: ScreenTimeServices = get()
                 screenTimeServices.startLimitsService()
             }
-        }.invokeOnCompletion {
-            scope.cancel()
-        }
+        }.invokeOnCompletion { scope.cancel() }
 
         // Setup Resume Apps worker
         ResumeAppsWork.run {

--- a/android/app/src/main/kotlin/work/racka/reluct/ui/MainActivity.kt
+++ b/android/app/src/main/kotlin/work/racka/reluct/ui/MainActivity.kt
@@ -90,44 +90,34 @@ class MainActivity : ComponentActivity() {
      * Function to tackle https://issuetracker.google.com/issues/227926002.
      * This will trigger the compose NavHost to load the startDestination without having a user input.
      */
-    private fun triggerBackgroundChangeIfNeeded(){
-
-        if(isMiui()){
-
+    private fun triggerBackgroundChangeIfNeeded() {
+        if (isMiui()) {
             lifecycleScope.launch {
                 delay(400)
                 window.setBackgroundDrawableResource(android.R.color.transparent)
             }
-
         }
-
     }
 
     /**
      * Function to determine if the device runs on MIUI by Xiaomi.
      */
     private fun isMiui(): Boolean {
-
         return try {
-
             Class
                 .forName("android.os.SystemProperties")
                 .getMethod("get", String::class.java)
-                .let{ propertyClass ->
-
+                .let { propertyClass ->
                     propertyClass
                         .invoke(propertyClass, "ro.miui.ui.version.name")
                         ?.toString()
                         ?.isNotEmpty()
                         ?: false
-
                 }
-
-        } catch ( e : Exception ) {
-            //e.printStackTrace()
+        } catch (e: Exception) {
+            // e.printStackTrace()
+            println("Property not found: ${e.message}")
             false
         }
-
     }
-
 }

--- a/common/features/screen-time/src/androidMain/kotlin/work/racka/reluct/common/features/screenTime/services/RestartScreenTimeServiceReceiver.kt
+++ b/common/features/screen-time/src/androidMain/kotlin/work/racka/reluct/common/features/screenTime/services/RestartScreenTimeServiceReceiver.kt
@@ -4,8 +4,14 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
 import work.racka.reluct.common.features.screenTime.permissions.UsageAccessPermission
+import work.racka.reluct.common.settings.MultiplatformSettings
 
 internal class RestartScreenTimeServiceReceiver : BroadcastReceiver(), KoinComponent {
 
@@ -15,18 +21,27 @@ internal class RestartScreenTimeServiceReceiver : BroadcastReceiver(), KoinCompo
             intent.action == "android.intent.action.QUICKBOOT_POWERON" ||
             intent.action == "com.htc.intent.action.QUICKBOOT_POWERON"
         ) {
-            val notification = UsageAccessPermission.requestUsageAccessNotification(context)
-            if (UsageAccessPermission.isAllowed(context)) {
-                notification.cancel()
-                val service = Intent(context, ScreenTimeLimitService::class.java)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    context.startForegroundService(service)
+            val scope = MainScope()
+            scope.launch {
+                val settings = get<MultiplatformSettings>()
+                val notification = UsageAccessPermission.requestUsageAccessNotification(context)
+
+                val onBoarding = settings.onBoardingShown.firstOrNull()
+                val isAppBlocking = settings.appBlockingEnabled.firstOrNull()
+                val canContinue = onBoarding == true && isAppBlocking == true
+
+                if (UsageAccessPermission.isAllowed(context) && canContinue) {
+                    notification.cancel()
+                    val service = Intent(context, ScreenTimeLimitService::class.java)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        context.startForegroundService(service)
+                    } else {
+                        context.startService(service)
+                    }
                 } else {
-                    context.startService(service)
+                    notification.show()
                 }
-            } else {
-                notification.show()
-            }
+            }.invokeOnCompletion { scope.cancel() }
         }
     }
 }


### PR DESCRIPTION
This add a check for user settings when the Restart service is called on device boot/restart